### PR TITLE
Fixed the Searchbar Appereance

### DIFF
--- a/client/src/components/UI/SearchBar/SearchBar.module.css
+++ b/client/src/components/UI/SearchBar/SearchBar.module.css
@@ -2,9 +2,8 @@
   max-width: 500px;
 }
 
-.searchbar{
+input.searchbar{
     height: 50px;
-
     font-size: 32px;
     font-weight: 350;
     box-shadow: inset 0px 4px 4px 0px rgba(0, 0, 0, 25%);
@@ -12,19 +11,19 @@
 }
 
 /* color of the "  Search" placeholder */
-.searchbar::placeholder {  
-    color: #8C8C8C;
+input.searchbar::placeholder {  
+    color: #8C8C8C ;
     opacity: 1; /* Because Firefox reduces opacity by default */
 }
-searchbar::-webkit-input-placeholder { /* Chrome/Opera/Safari */
+input.searchbar::-webkit-input-placeholder { /* Chrome/Opera/Safari */
     color: #8C8C8C;
 }
-.searchbar::-moz-placeholder { /* Firefox 19+ */
+input.searchbar::-moz-placeholder { /* Firefox 19+ */
   color: #8C8C8C;
 }
-.searchbar:-ms-input-placeholder { /* IE 10+ */
+input.searchbar:-ms-input-placeholder { /* IE 10+ */
   color: #8C8C8C;
 }
-.searchbar:-moz-placeholder { /* Firefox 18- */
+input.searchbar:-moz-placeholder { /* Firefox 18- */
   color: #8C8C8C;
 }

--- a/client/src/components/UI/SearchBar/SearchBar.tsx
+++ b/client/src/components/UI/SearchBar/SearchBar.tsx
@@ -9,7 +9,7 @@ export function SearchBar() {
         <Form.Control
           type="search"
           className={`rounded-4 ${classes.searchbar}`}
-          placeholder="Search"
+          placeholder="  Search"
           aria-label="Search"
         />
         {/* Seach Icon on the right */}

--- a/client/src/components/UI/SearchBar/SearchBar.tsx
+++ b/client/src/components/UI/SearchBar/SearchBar.tsx
@@ -9,7 +9,7 @@ export function SearchBar() {
         <Form.Control
           type="search"
           className={`rounded-4 ${classes.searchbar}`}
-          placeholder="  Search"
+          placeholder="Search"
           aria-label="Search"
         />
         {/* Seach Icon on the right */}


### PR DESCRIPTION
This is how it used to look:
![image](https://github.com/user-attachments/assets/035345fd-ba4c-432a-93e4-530617a1c229)
This is how it looks now
![Screenshot 2025-05-02 133545](https://github.com/user-attachments/assets/0f1fce1c-b938-4776-bc35-65c243514dae)

So, I removed the white border and fixed the search font and weight